### PR TITLE
fix: gradle.yml의 scp-action rm 속성 제거

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -89,7 +89,7 @@ jobs:
           source: "deploy/deploy.sh"
           target: "/home/ec2-user"
           strip_components: 1
-          rm: true
+          overwrite: true
 
 
       - name: Docker Image Pull and Container run


### PR DESCRIPTION
scp-action의 rm 속성은 scp 하기 전 target 서버의 디렉토리의 내용을 지우는 명령어
이 속성 말고 overwrite로 대체