### PR TITLE
fix: github actions 스크립트에 불필요한 스크립트 제거

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,23 +25,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: ls -al
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'oracle'
-          cache: 'gradle'
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Grant execute permission for gradlew
-        run: |
-          chmod u+w ./api-module/src/main/resources
-          chmod +x ./gradlew
-          ./gradlew clean
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,10 @@ WORKDIR /sources
 
 COPY . .
 
-RUN chmod +x gradlew
-
-RUN ./gradlew :api-module:build
+RUN chmod u+w ./api-module/src/main/resources && \
+    chmod +x gradlew &&  \
+    ./gradlew clean &&  \
+    ./gradlew :api-module:build
 
 FROM optimoz/openjre-21.0.3:0.4
 


### PR DESCRIPTION
도커파일에서 gradlew build 관련 스크립트가 있음에도 github actions 스크립트에 gradle 설정이 존재해서 제거